### PR TITLE
Add dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./crmapp.js": "./dist/src/crmapp.js"
   },
   "scripts": {
+    "dev": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",


### PR DESCRIPTION
Added a new "dev" script to package.json that mirrors the existing "start" script functionality. This provides developers with a more conventional npm command for local development.

The dev script runs:
- TypeScript compilation
- Concurrent TypeScript watch mode
- Web dev server

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=orbit-space&projectId=ec622bdaf7b648b6a5f85f48397f8dc9)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ec622bdaf7b648b6a5f85f48397f8dc9</projectId>-->